### PR TITLE
Fix: example/library warnings

### DIFF
--- a/example/example_functions.h
+++ b/example/example_functions.h
@@ -1,13 +1,13 @@
 #include "stdbool.h"
 
-int sum_int( int x, int y ) { return x + y; }
+static inline int sum_int( int x, int y ) { return x + y; }
 
-int *int_ptr( int *x ) { return x; }
+static inline int *int_ptr( int *x ) { return x; }
 
-float sum_float( float x, float y ) { return x + y; }
+static inline float sum_float( float x, float y ) { return x + y; }
 
-bool is_odd( int x ) { return ( x % 2 ) != 0; }
+static inline bool is_odd( int x ) { return ( x % 2 ) != 0; }
 
-bool is_n( char c ) { return c == 'n'; }
+static inline bool is_n( char c ) { return c == 'n'; }
 
-char next_char( char c ) { return ++c; }
+static inline char next_char( char c ) { return ++c; }

--- a/example/example_tests.c
+++ b/example/example_tests.c
@@ -107,7 +107,7 @@ void test_size()
 
 void test_ignored() {}
 
-int main()
+int main(void)
 {
 	// single test
 	NANO_SINGLE_TEST( test_is_n );

--- a/src/lib.h
+++ b/src/lib.h
@@ -72,7 +72,8 @@ enum T_TYPES
 #define NANO_ASSERT_EQ_INT( TESTNAME, expected, actual )                                                               \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_INT && Type( actual ) == T_INT ) );                            \
+		_Static_assert( ( Type( expected ) == T_INT && Type( actual ) == T_INT ),                              \
+				"Actual and expected must be in int type" );                                           \
 		if ( expected != actual )                                                                              \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected: %d, got: %d.\n", TESTNAME,       \
@@ -93,7 +94,8 @@ enum T_TYPES
 #define NANO_ASSERT_GE_INT( TESTNAME, expected, actual )                                                               \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_INT && Type( actual ) == T_INT ) );                            \
+		_Static_assert( ( Type( expected ) == T_INT && Type( actual ) == T_INT ),                              \
+				"Actual and expected must be in int type" );                                           \
 		if ( expected > actual )                                                                               \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected %d to be greater than %d.\n",     \
@@ -114,7 +116,8 @@ enum T_TYPES
 #define NANO_ASSERT_LE_INT( TESTNAME, expected, actual )                                                               \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_INT && Type( actual ) == T_INT ) );                            \
+		_Static_assert( ( Type( expected ) == T_INT && Type( actual ) == T_INT ),                              \
+				"Actual and expected must be in int type" );                                           \
 		if ( expected < actual )                                                                               \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected %d to be less than %d.\n",        \
@@ -135,7 +138,8 @@ enum T_TYPES
 #define NANO_ASSERT_NOTEQ_INT( TESTNAME, expected, actual )                                                            \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_INT && Type( actual ) == T_INT ) );                            \
+		_Static_assert( ( Type( expected ) == T_INT && Type( actual ) == T_INT ),                              \
+				"Actual and expected must be in int type" );                                           \
 		if ( expected == actual )                                                                              \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: %d not expected to be equal to %d .\n",    \
@@ -156,7 +160,8 @@ enum T_TYPES
 #define NANO_ASSERT_EQ_FLOAT( TESTNAME, expected, actual )                                                             \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_FLOAT && Type( actual ) == T_FLOAT ) );                        \
+		_Static_assert( ( Type( expected ) == T_FLOAT && Type( actual ) == T_FLOAT ),                          \
+				"Actual and expected must be in float type" );                                         \
 		if ( expected != actual )                                                                              \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected %f, got: %f.\n", TESTNAME,        \
@@ -177,7 +182,8 @@ enum T_TYPES
 #define NANO_ASSERT_NOTEQ_FLOAT( TESTNAME, expected, actual )                                                          \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_FLOAT && Type( actual ) == T_FLOAT ) );                        \
+		_Static_assert( ( Type( expected ) == T_FLOAT && Type( actual ) == T_FLOAT ),                          \
+				"Actual and expected must be in float type" );                                         \
 		if ( expected == actual )                                                                              \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected: %f, got: %f.\n", TESTNAME,       \
@@ -198,7 +204,8 @@ enum T_TYPES
 #define NANO_ASSERT_GE_FLOAT( TESTNAME, expected, actual )                                                             \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_FLOAT && Type( actual ) == T_FLOAT ) );                        \
+		_Static_assert( ( Type( expected ) == T_FLOAT && Type( actual ) == T_FLOAT ),                          \
+				"Actual and expected must be in float type" );                                         \
 		if ( expected > actual )                                                                               \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected %f to be greater than %f.\n",     \
@@ -219,7 +226,8 @@ enum T_TYPES
 #define NANO_ASSERT_LE_FLOAT( TESTNAME, expected, actual )                                                             \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_FLOAT && Type( actual ) == T_FLOAT ) );                        \
+		_Static_assert( ( Type( expected ) == T_FLOAT && Type( actual ) == T_FLOAT ),                          \
+				"Actual and expected must be in float type" );                                         \
 		if ( expected < actual )                                                                               \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected %f to be less than %f.\n",        \
@@ -240,7 +248,8 @@ enum T_TYPES
 #define NANO_ASSERT_EQ_CHAR( TESTNAME, expected, actual )                                                              \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_CHAR && Type( actual ) == T_CHAR ) );                          \
+		_Static_assert( ( Type( expected ) == T_CHAR && Type( actual ) == T_CHAR ),                            \
+				"Actual and expected must be in char type" );                                          \
 		if ( expected != actual )                                                                              \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected '%c', got: '%c'.\n", TESTNAME,    \
@@ -261,7 +270,8 @@ enum T_TYPES
 #define NANO_ASSERT_NOTEQ_CHAR( TESTNAME, expected, actual )                                                           \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( expected ) == T_CHAR && Type( actual ) == T_CHAR ) );                          \
+		_Static_assert( ( Type( expected ) == T_CHAR && Type( actual ) == T_CHAR ),                            \
+				"Actual and expected must be in char type" );                                          \
 		if ( expected == actual )                                                                              \
 		{                                                                                                      \
 			fprintf( stderr, "\t\"%s\" file: %s line: %d Error: expected '%c', got: '%c'.\n", TESTNAME,    \
@@ -321,7 +331,7 @@ enum T_TYPES
 #define NANO_ASSERT_TRUE( TESTNAME, actual )                                                                           \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( actual ) == T_BOOL ) );                                                        \
+		_Static_assert( ( Type( actual ) == T_BOOL ), "Actual must be in bool type" );                         \
 		if ( !actual )                                                                                         \
 		{                                                                                                      \
 			fprintf(                                                                                       \
@@ -343,7 +353,7 @@ enum T_TYPES
 #define NANO_ASSERT_FALSE( TESTNAME, actual )                                                                          \
 	do                                                                                                             \
 	{                                                                                                              \
-		_Static_assert( ( Type( actual ) == T_BOOL ) );                                                        \
+		_Static_assert( ( Type( actual ) == T_BOOL ), "Actual must be in bool type" );                         \
 		if ( actual )                                                                                          \
 		{                                                                                                      \
 			fprintf(                                                                                       \


### PR DESCRIPTION
This PR fixes the warnings due to the lack of message from the assertion and header file.