### PR TITLE
Fixed: too many arguments provided to function-like macro invocation.

### DIFF
--- a/example/example_tests.c
+++ b/example/example_tests.c
@@ -3,9 +3,7 @@
 #include <stdbool.h>
 
 NANO_FUNCTION( test_sum_int, {
-	int x;
-	int y;
-	int result;
+	int x, y, result;
 
 	x = 3;
 	y = 4;
@@ -34,9 +32,7 @@ NANO_FUNCTION( test_sum_int, {
 } )
 
 NANO_FUNCTION( test_sum_float, {
-	float x;
-	float y;
-	float result;
+	float x, y, result;
 
 	x = 3.1f;
 	y = 4.4f;

--- a/src/lib.h
+++ b/src/lib.h
@@ -562,14 +562,14 @@ static unsigned int TOTAL_SUCCESSFUL_COUNTER_PER_FUNCTION = 0;
  * @param FUNCTIONNAME Name of test function.
  * @param CODEBLOCK Place a block of code that will run in the function.
 **/
-#define NANO_FUNCTION( FUNCTIONNAME, CODEBLOCK )                                                                       \
+#define NANO_FUNCTION( FUNCTIONNAME, ... )                                                                             \
 	void FUNCTIONNAME( void )                                                                                      \
 	{                                                                                                              \
 		TOTAL_TEST_COUNTER_PER_FUNCTION = 0;                                                                   \
 		TOTAL_FAILED_COUNTER_PER_FUNCTION = 0;                                                                 \
 		TOTAL_SUCCESSFUL_COUNTER_PER_FUNCTION = 0;                                                             \
 		fprintf( stderr, ">>> %s\n\n", #FUNCTIONNAME );                                                        \
-		CODEBLOCK;                                                                                             \
+		__VA_ARGS__;                                                                                           \
 		fprintf( stderr, "\r\nTESTS: (%u) | SUCCESSFUL: (%u) | FAILED: (%u)\r\n",                              \
 			 TOTAL_TEST_COUNTER_PER_FUNCTION, TOTAL_SUCCESSFUL_COUNTER_PER_FUNCTION,                       \
 			 TOTAL_FAILED_COUNTER_PER_FUNCTION );                                                          \
@@ -580,10 +580,10 @@ static unsigned int TOTAL_SUCCESSFUL_COUNTER_PER_FUNCTION = 0;
  * @brief The main function constructor.
  * @param CODEBLOCK Place a block of code that will run in the main function.
 **/
-#define NANO_MAIN( CODEBLOCK )                                                                                         \
+#define NANO_MAIN( ... )                                                                                               \
 	int main( void )                                                                                               \
 	{                                                                                                              \
-		CODEBLOCK;                                                                                             \
+		__VA_ARGS__;                                                                                           \
 		fprintf( stderr,                                                                                       \
 			 "\r\nTOTAL TESTS: (%u) | TOTAL SUCCESSFUL TESTS: (%u) | TOTAL FAILED TESTS: (%u) | TOTAL "    \
 			 "IGNORED TESTS: (%u)\r\n",                                                                    \


### PR DESCRIPTION
Fixed this issue ( #9 ) by replacing the CODEBLOCK argument with __VA_ARGS__.